### PR TITLE
Refactor/loadingux

### DIFF
--- a/app/@locationModal/(.)location/[id]/page.tsx
+++ b/app/@locationModal/(.)location/[id]/page.tsx
@@ -98,7 +98,6 @@ export default function Page(props: PageProps) {
                                                 .height
                                         }
                                         className="w-[80%] my-4"
-                                        priority={true}
                                     />
                                 )}
                                 <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">

--- a/app/components/BookCard.tsx
+++ b/app/components/BookCard.tsx
@@ -1,7 +1,6 @@
 import { Book } from "@/app/utils/db";
 import { getImageSrc } from "@/app/utils/util";
 import Image from "next/image";
-import Link from "next/link";
 import ToLocationButton from "@/app/components/ToLocationButton";
 
 export default function BookCard({

--- a/app/components/BookCard.tsx
+++ b/app/components/BookCard.tsx
@@ -2,6 +2,7 @@ import { Book } from "@/app/utils/db";
 import { getImageSrc } from "@/app/utils/util";
 import Image from "next/image";
 import Link from "next/link";
+import ToLocationButton from "@/app/components/ToLocationButton";
 
 export default function BookCard({
     bookObj,
@@ -50,12 +51,7 @@ export default function BookCard({
                     </div>
                     {!isAboutLocation && (
                         <div className="self-end sm:self-center text-xs md:text-sm lg:text-md">
-                            <Link
-                                href={`/location/${bookObj.id}`}
-                                className="bg-skeleton text-text-primary px-4 py-2 rounded-md hover:bg-skeleton-hover transition-colors whitespace-nowrap"
-                            >
-                                위치 보기 →
-                            </Link>
+                            <ToLocationButton bookId={bookObj.id} />
                         </div>
                     )}
                 </div>

--- a/app/components/InputBox.tsx
+++ b/app/components/InputBox.tsx
@@ -1,20 +1,28 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import InitialNotification from "@/app/components/InitialNotification";
 import { Search } from "lucide-react";
-// import SearchResults from "@/app/components/SearchResults";
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { KeyboardEvent } from "react";
 
 const QUERY = "query";
 
 export default function InputBox() {
+    const [isSearching, setIsSearching] = useState(false);
+    const [searchingKeyword, setSearchingKeyword] = useState(null);
+    // 현재 검색 쿼리
     const searchParams = useSearchParams();
-    // handleSearchParamsChange 뿐만 아니라, 다른 핸들러에도 사용해야 하는데,
-    // 여기서 사용하는 리렌더링 관련 훅이 없으므로 최상단에 노출시킴
+    // 검색할 새로운 쿼리
     const params = new URLSearchParams(searchParams);
     const pathname = usePathname();
     const { push } = useRouter();
+
+    useEffect(() => {
+        setIsSearching(false);
+        setSearchingKeyword(null);
+    }, [searchParams]);
 
     const handleSearchParamsChange = (term: string) => {
         const trimmedTerm = term.trim();
@@ -26,7 +34,13 @@ export default function InputBox() {
     };
 
     const handleSubmit = () => {
-        if (params.get(QUERY)) push(`${pathname}?${params.toString()}`);
+        const currentQuery = searchParams.get(QUERY);
+        const newQuery = params.get(QUERY);
+        // 검색어가 있고, 현재 검색어와 다를 때
+        if (newQuery && newQuery !== currentQuery) {
+            setIsSearching(true);
+            push(`${pathname}?${params.toString()}`);
+        }
     };
 
     const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -34,8 +48,14 @@ export default function InputBox() {
     };
 
     const onKeywordClick = (keyword: string) => {
-        params.set(QUERY, keyword.trim());
-        push(`${pathname}?${params.toString()}`);
+        const currentQuery = searchParams.get(QUERY);
+        const newQuery = keyword.trim();
+        // 검색어가 있고, 현재 검색어와 다를 때
+        if (newQuery !== currentQuery) {
+            params.set(QUERY, newQuery);
+            setSearchingKeyword(keyword);
+            push(`${pathname}?${params.toString()}`);
+        }
     };
 
     return (
@@ -55,27 +75,54 @@ export default function InputBox() {
                     />
                     <button
                         onClick={handleSubmit}
-                        className="bg-button-bg text-text-primary px-4 sm:px-6 py-2 sm:py-3  rounded-lg hover:bg-button-bg-hover transition-colors flex items-center gap-2"
+                        disabled={isSearching}
+                        aria-label="검색"
+                        aria-disabled={isSearching}
+                        className="bg-button-bg text-text-primary px-4 sm:px-6 py-2 sm:py-3  rounded-lg hover:bg-button-bg-hover transition-colors flex items-center gap-2 disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                        <Search className="w-[min(calc(((100vw-128px))/20),16px)] h-[min(calc(((100vw-128px))/20),16px)]" />
-                        검색
+                        {isSearching ? (
+                            <>
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                <span>위치 찾는 중...</span>
+                            </>
+                        ) : (
+                            <>
+                                <Search className="w-[min(calc(((100vw-128px))/20),16px)] h-[min(calc(((100vw-128px))/20),16px)]" />
+                                검색
+                            </>
+                        )}
                     </button>
                 </div>
                 <div className="ml-3 flex items-center gap-2 text-muted-foreground text-text-secondary text-[min(calc(((100vw-84px-1.5rem))/24),14px)]">
                     추천 검색어:
                     <div className="flex flex-wrap gap-3">
                         {["바보", "그대를 사랑합니다", "무빙"].map(
-                            (keyword) => (
-                                <button
-                                    key={keyword}
-                                    onClick={() => onKeywordClick(keyword)}
-                                    className="px-2 py-1 sm:px-4 sm:py-2 bg-button-bg/10 text-text-primary bg-button-bg
-						rounded-full hover:bg-text-primary/20 transition-colors
-						active:ring-2 active:ring-text-primary/50 active:bg-text-primary/50"
-                                >
-                                    {keyword}
-                                </button>
-                            )
+                            (keyword) => {
+                                const isKeywordSearching =
+                                    searchingKeyword === keyword;
+                                return (
+                                    <button
+                                        key={keyword}
+                                        onClick={() => onKeywordClick(keyword)}
+                                        disabled={isKeywordSearching}
+                                        aria-label={`${keyword} 검색`}
+                                        aria-disabled={isKeywordSearching}
+                                        className="px-2 py-1 sm:px-4 sm:py-2 bg-button-bg/10 text-text-primary bg-button-bg
+						rounded-full flex gap-2 items-center hover:bg-text-primary/20 transition-colors
+						active:ring-2 active:ring-text-primary/50 active:bg-text-primary/50
+						disabled:cursor-not-allowed disabled:opacity-50"
+                                    >
+                                        {isKeywordSearching ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" />
+                                                <span>검색 중...</span>
+                                            </>
+                                        ) : (
+                                            keyword
+                                        )}
+                                    </button>
+                                );
+                            }
                         )}
                     </div>
                 </div>

--- a/app/components/InputBox.tsx
+++ b/app/components/InputBox.tsx
@@ -83,7 +83,7 @@ export default function InputBox() {
                         {isSearching ? (
                             <>
                                 <Loader2 className="h-4 w-4 animate-spin" />
-                                <span>위치 찾는 중...</span>
+                                <span>도서 찾는 중...</span>
                             </>
                         ) : (
                             <>

--- a/app/components/InputBox.tsx
+++ b/app/components/InputBox.tsx
@@ -11,7 +11,9 @@ const QUERY = "query";
 
 export default function InputBox() {
     const [isSearching, setIsSearching] = useState(false);
-    const [searchingKeyword, setSearchingKeyword] = useState(null);
+    const [searchingKeyword, setSearchingKeyword] = useState<string | null>(
+        null
+    );
     // 현재 검색 쿼리
     const searchParams = useSearchParams();
     // 검색할 새로운 쿼리

--- a/app/components/ToLocationButton.tsx
+++ b/app/components/ToLocationButton.tsx
@@ -12,13 +12,15 @@ export default function ToLocationButton({ bookId }: { bookId: number }) {
     useEffect(() => {
         pathname !== "/" && setIsLoading(false);
     }, [pathname]);
-
+    console.log(isLoading);
     return (
         <Link
             href={`/location/${bookId}`}
-            className="bg-skeleton text-text-primary px-4 py-2 rounded-md hover:bg-skeleton-hover transition-colors whitespace-nowrap inline-flex items-center gap-2 disabled:opacity-50"
+            className={
+                "bg-skeleton text-text-primary px-4 py-2 rounded-md hover:bg-skeleton-hover transition-colors whitespace-nowrap inline-flex items-center gap-2 " +
+                (isLoading ? "cursor-not-allowed opacity-50" : "")
+            }
             onClick={() => setIsLoading(true)}
-            disabled={isLoading}
             aria-label="위치 보기"
             aria-disabled={isLoading}
         >

--- a/app/components/ToLocationButton.tsx
+++ b/app/components/ToLocationButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function ToLocationButton({ bookId }: { bookId: number }) {
+    const [isLoading, setIsLoading] = useState(false);
+    const pathname = usePathname();
+
+    useEffect(() => {
+        pathname !== "/" && setIsLoading(false);
+    }, [pathname]);
+
+    return (
+        <Link
+            href={`/location/${bookId}`}
+            className="bg-skeleton text-text-primary px-4 py-2 rounded-md hover:bg-skeleton-hover transition-colors whitespace-nowrap inline-flex items-center gap-2 disabled:opacity-50"
+            onClick={() => setIsLoading(true)}
+            disabled={isLoading}
+            aria-label="위치 보기"
+            aria-disabled={isLoading}
+        >
+            {isLoading ? (
+                <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>위치 찾는 중...</span>
+                </>
+            ) : (
+                "위치 보기 →"
+            )}
+        </Link>
+    );
+}

--- a/app/components/ToLocationButton.tsx
+++ b/app/components/ToLocationButton.tsx
@@ -10,9 +10,11 @@ export default function ToLocationButton({ bookId }: { bookId: number }) {
     const pathname = usePathname();
 
     useEffect(() => {
-        pathname !== "/" && setIsLoading(false);
+        if (pathname !== "/") {
+            setIsLoading(false); // 함수 호출로 수정
+        }
     }, [pathname]);
-    console.log(isLoading);
+
     return (
         <Link
             href={`/location/${bookId}`}

--- a/app/location/[id]/page.tsx
+++ b/app/location/[id]/page.tsx
@@ -152,7 +152,6 @@ export default async function Page(props: PageProps) {
                         width={FLOOR_IMAGE_SIZE[bookInfo.floor].width}
                         height={FLOOR_IMAGE_SIZE[bookInfo.floor].height}
                         className="w-[80%] my-4"
-                        priority={true}
                     />
                     <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
                         <GobackButton toHome />


### PR DESCRIPTION
- location 조감도 `Image`의 `priority`를 비활성화하여 lazy loading 처리: 라우트 렌더링 시작 자체를 빠르게 개선
- loading UI로 UX 개선
  - 검색어 입력 후 keydown 혹은 검색 버튼 클릭
    <img width="331" alt="스크린샷 2025-04-03 오후 3 26 22" src="https://github.com/user-attachments/assets/25cb30fe-cf21-4764-8fdc-5c894600cd2f" />
  - 추천 검색어 클릭
    <img width="417" alt="스크린샷 2025-04-03 오후 2 56 13" src="https://github.com/user-attachments/assets/c53ce3e5-d46b-4f34-ae06-62f2a7f9a189" />
  - '위치 보기' 클릭: a 태그라 dynamic className 사용
    <img width="420" alt="스크린샷 2025-04-03 오후 3 14 53" src="https://github.com/user-attachments/assets/806cd977-5adc-45cd-8fd8-94ab8a8e1792" />
