### PR TITLE
Refactor/prevent location layout shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,3 +474,11 @@ const LOCATION_POSITION: {
 <br />
 
 <strong>2025.04.08</strong>: 이미지 사이즈를 최대한 크게 보여주도록 조정 및 hard navigation location 페이지에서는 뒤로 가기 버튼을 왼쪽 위로 변경
+
+<details>
+<summary><strong>2025.04.09</strong>: soft navigation location 이미지 로드되기 전 로딩 박스 보여주어 layout shift 방지</summary>
+
+padding-top으로 aspect-ratio에 맞게 빈 박스를 만들 수 있다!
+
+</details>
+<br />

--- a/app/@locationModal/(.)location/[id]/page.tsx
+++ b/app/@locationModal/(.)location/[id]/page.tsx
@@ -9,6 +9,8 @@ interface PageProps {
     params: Promise<{ id: string }>;
 }
 
+const LOCATION_IMAGE_RATIO_CLASSNAME = "pt-[79.67754031%]";
+
 export default function Page(props: PageProps) {
     const [bookInfo, setBookInfo] = useState<{
         location: number;
@@ -52,23 +54,26 @@ export default function Page(props: PageProps) {
 
             <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
                 <div className="flex min-h-full justify-center p-4 text-center items-center">
-                    <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-3xl px-4 flex flex-col items-center">
-                        {bookInfo && (
-                            <>
-                                {bookInfo.location && (
-                                    <Image
-                                        src={`/location${bookInfo.location}.jpg`}
-                                        alt={bookInfo.location + `번 책장 위치`}
-                                        width={LOCATION_IMAGE_SIZE.width}
-                                        height={LOCATION_IMAGE_SIZE.height}
-                                        className="w-full"
-                                    />
-                                )}
-                                <div className="px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-                                    <GobackButton />
-                                </div>
-                            </>
+                    <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-3xl px-4 pb-3 flex flex-col items-center">
+                        {bookInfo?.location ? (
+                            <Image
+                                src={`/location${bookInfo.location}.jpg`}
+                                alt={bookInfo.location + `번 책장 위치`}
+                                width={LOCATION_IMAGE_SIZE.width}
+                                height={LOCATION_IMAGE_SIZE.height}
+                                className="w-full"
+                            />
+                        ) : (
+                            <div
+                                className={
+                                    LOCATION_IMAGE_RATIO_CLASSNAME +
+                                    " mt-3 w-full bg-card-bg rounded-xl animate-pulse"
+                                }
+                            />
                         )}
+                        <div className="px-4 pt-3 sm:flex sm:flex-row-reverse sm:px-6">
+                            <GobackButton />
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
soft navigation location Route는 클라이언트 사이드 페이지이다 보니, Image 컴포넌트가 제대로 이미지를 로드하기 전에 먼저 마운트되버려 layout shift가 발생
-> Padding top을 활용하여 이미지 Placeholder를 보여줘 이를 방지
